### PR TITLE
use value of statuses to replace '@', set default string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+node_modules

--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ yields
 </div>
 ```
 
+## Dynamic value in conditional classes
+```jade
+import classnames from 'ui-kit-classnames'
+var $ = classnames('StatusComponent', props, {'is-global-@': 'baz'})
+
+//- passing no argument here is the same as '&'
+div(class=$())
+  div(class=$('>-foo', {'local-@': 'dynamic'}))
+  div(class=$('>-bar', {'local-@': ''}))
+```
+
+yields
+
+```html
+<div class="StatusComponent StatusComponent-is-global-baz">
+  <div class="StatusComponent-foo StatusComponent-foo-is-global-baz StatusComponent-foo-local-dynamic"></div>
+  <div class="StatusComponent-bar StatusComponent-bar-is-global-baz"></div>
+</div>
+```
+
+
 ## Rewrite base
 
 `thing.jade`

--- a/lib/ClassNames.js
+++ b/lib/ClassNames.js
@@ -11,8 +11,8 @@ function ClassNames (bases, statuses) {
 };
 
 ClassNames.prototype.stringify = function(string, statuses) {
+  string = string || '&';
   var level = 0;
-
   if (string.charCodeAt(0) === ARROW_CODE) {
     var indent = string.split('-')[0].length;
     string = string.slice(indent);
@@ -27,6 +27,7 @@ ClassNames.prototype.stringify = function(string, statuses) {
   statuses = Object.assign({}, this.statuses, statuses);
   for (var k in statuses) {
     if (!statuses[k]) continue;
+    k = k.replace('@', statuses[k]);
     buf.push(value + '-' + toSpinalCase(k));
   }
   buf = buf.join(' ');

--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
     "test": "mocha"
   },
   "author": "Michael Andrew Vanasse <mail@mndvns.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "mocha": "^3.2.0",
+    "should": "^11.2.1"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,11 @@ describe('ClassNames', function() {
     $('>-2B').should.eql('1-2B');
   });
 
+  it('should accept empty arguments', function () {
+    var $ = classnames('foo', null, {isGlobal1: true, isGlobal2: false});
+    'foo foo-is-global-1'.should.eql($());
+  })
+
   it('should append conditional classes', function() {
     var $ = classnames('2', null, {isGlobal1: true, isGlobal2: false});
     '2 2-is-global-1'.should.eql($('&'));
@@ -20,10 +25,18 @@ describe('ClassNames', function() {
     '2-bar 2-bar-is-global-1 2-bar-this-is-true'.should.eql($('>-bar', {thisIsTrue: true}));
   });
 
+  it('should append value of status with at symbol', function() {
+    var $ = classnames('foo', null, {'is-global-@': 'bar'});
+    'foo foo-is-global-bar'.should.eql($('&'));
+    'foo-nest foo-nest-is-global-bar'.should.eql($('>-nest', {'local-@': false}));
+    'foo-baz foo-baz-is-global-bar foo-baz-local-lucy'.should.eql($('>-baz',  {'local-@': 'lucy'}));
+  })
+
   it('should rewrite the base', function() {
     var $ = prop => classnames('3', {'&': prop}, {condition: true});
     'R R-condition'.should.eql($('R')('&'));
     '3 3-condition R R-condition'.should.eql($('& R')('&'));
     '3 3-condition W W-condition'.should.eql($(['&', 'W'])('&'));
   });
+
 });


### PR DESCRIPTION
This allows for a simple way to add many classes with one line.

For example 
```
$('&-component', {}, {'type-@': props.type}
``` 
Where type is either "text" or "image".
